### PR TITLE
[OEM] Let OEM customize headunit information: Make/Manufacturer

### DIFF
--- a/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
@@ -65,6 +65,10 @@ public:
     std::string getBluetoothRemoteAdapterAddress() const override;
     void setBluetoothRemoteAdapterAddress(const std::string& value) override;
 
+    std::string getHeadUnitName() const override;
+    std::string getHeadUnitManufacturer() const override;
+    std::string getHeadUnitModel() const override;
+
     bool musicAudioChannelEnabled() const override;
     void setMusicAudioChannelEnabled(bool value) override;
     bool speechAudioChannelEnabled() const override;
@@ -88,11 +92,18 @@ private:
     ButtonCodes buttonCodes_;
     BluetoothAdapterType bluetoothAdapterType_;
     std::string bluetoothRemoteAdapterAddress_;
+    std::string headUnitName_;
+    std::string headUnitManufacturer_;
+    std::string headUnitModel_;
     bool musicAudioChannelEnabled_;
     bool speechAudiochannelEnabled_;
     AudioOutputBackendType audioOutputBackendType_;
 
     static const std::string cConfigFileName;
+
+    static const std::string cHeadUnitNameKey;
+    static const std::string cHeadUnitManufacturerKey;
+    static const std::string cHeadUnitModelKey;
 
     static const std::string cGeneralShowClockKey;
     static const std::string cGeneralHandednessOfTrafficTypeKey;

--- a/include/f1x/openauto/autoapp/Configuration/IConfiguration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/IConfiguration.hpp
@@ -74,6 +74,10 @@ public:
     virtual std::string getBluetoothRemoteAdapterAddress() const = 0;
     virtual void setBluetoothRemoteAdapterAddress(const std::string& value) = 0;
 
+    virtual std::string getHeadUnitName() const = 0;
+    virtual std::string getHeadUnitManufacturer() const = 0;
+    virtual std::string getHeadUnitModel() const = 0;
+
     virtual bool musicAudioChannelEnabled() const = 0;
     virtual void setMusicAudioChannelEnabled(bool value) = 0;
     virtual bool speechAudioChannelEnabled() const = 0;

--- a/src/autoapp/Configuration/Configuration.cpp
+++ b/src/autoapp/Configuration/Configuration.cpp
@@ -47,6 +47,10 @@ const std::string Configuration::cAudioOutputBackendType = "Audio.OutputBackendT
 const std::string Configuration::cBluetoothAdapterTypeKey = "Bluetooth.AdapterType";
 const std::string Configuration::cBluetoothRemoteAdapterAddressKey = "Bluetooth.RemoteAdapterAddress";
 
+const std::string Configuration::cHeadUnitNameKey = "OEM.HeadUnitName";
+const std::string Configuration::cHeadUnitManufacturerKey = "OEM.HeadUnitManufacturer";
+const std::string Configuration::cHeadUnitModelKey = "OEM.HeadUnitModel";
+
 const std::string Configuration::cInputEnableTouchscreenKey = "Input.EnableTouchscreen";
 const std::string Configuration::cInputPlayButtonKey = "Input.PlayButton";
 const std::string Configuration::cInputPauseButtonKey = "Input.PauseButton";
@@ -100,6 +104,10 @@ void Configuration::load()
 
         bluetoothRemoteAdapterAddress_ = iniConfig.get<std::string>(cBluetoothRemoteAdapterAddressKey, "");
 
+        headUnitName_ = iniConfig.get<std::string>(cHeadUnitNameKey, "OpenAuto");
+        headUnitManufacturer_ = iniConfig.get<std::string>(cHeadUnitManufacturerKey, "f1x");
+        headUnitModel_ = iniConfig.get<std::string>(cHeadUnitModelKey, "OpenAuto Autoapp");
+
         musicAudioChannelEnabled_ = iniConfig.get<bool>(cAudioMusicAudioChannelEnabled, true);
         speechAudiochannelEnabled_ = iniConfig.get<bool>(cAudioSpeechAudioChannelEnabled, true);
         audioOutputBackendType_ = static_cast<AudioOutputBackendType>(iniConfig.get<uint32_t>(cAudioOutputBackendType, static_cast<uint32_t>(AudioOutputBackendType::RTAUDIO)));
@@ -126,6 +134,9 @@ void Configuration::reset()
     buttonCodes_.clear();
     bluetoothAdapterType_ = BluetoothAdapterType::NONE;
     bluetoothRemoteAdapterAddress_ = "";
+    headUnitName_ = "OpenAuto";
+    headUnitManufacturer_ = "f1x";
+    headUnitModel_ = "OpenAuto Autoapp";
     musicAudioChannelEnabled_ = true;
     speechAudiochannelEnabled_ = true;
     audioOutputBackendType_ = AudioOutputBackendType::RTAUDIO;
@@ -264,6 +275,21 @@ std::string Configuration::getBluetoothRemoteAdapterAddress() const
 void Configuration::setBluetoothRemoteAdapterAddress(const std::string& value)
 {
     bluetoothRemoteAdapterAddress_ = value;
+}
+
+std::string Configuration::getHeadUnitName() const
+{
+    return headUnitName_;
+}
+
+std::string Configuration::getHeadUnitManufacturer() const
+{
+    return headUnitManufacturer_;
+}
+
+std::string Configuration::getHeadUnitModel() const
+{
+    return headUnitModel_;
 }
 
 bool Configuration::musicAudioChannelEnabled() const

--- a/src/autoapp/Service/AndroidAutoEntity.cpp
+++ b/src/autoapp/Service/AndroidAutoEntity.cpp
@@ -157,13 +157,13 @@ void AndroidAutoEntity::onServiceDiscoveryRequest(const aasdk::proto::messages::
 
     aasdk::proto::messages::ServiceDiscoveryResponse serviceDiscoveryResponse;
     serviceDiscoveryResponse.mutable_channels()->Reserve(256);
-    serviceDiscoveryResponse.set_head_unit_name("OpenAuto");
+    serviceDiscoveryResponse.set_head_unit_name(configuration_->getHeadUnitName());
     serviceDiscoveryResponse.set_car_model("Universal");
     serviceDiscoveryResponse.set_car_year("2018");
     serviceDiscoveryResponse.set_car_serial("20180301");
     serviceDiscoveryResponse.set_left_hand_drive_vehicle(configuration_->getHandednessOfTrafficType() == configuration::HandednessOfTrafficType::LEFT_HAND_DRIVE);
-    serviceDiscoveryResponse.set_headunit_manufacturer("f1x");
-    serviceDiscoveryResponse.set_headunit_model("OpenAuto Autoapp");
+    serviceDiscoveryResponse.set_headunit_manufacturer(configuration_->getHeadUnitManufacturer());
+    serviceDiscoveryResponse.set_headunit_model(configuration_->getHeadUnitModel());
     serviceDiscoveryResponse.set_sw_build("1");
     serviceDiscoveryResponse.set_sw_version("1.0");
     serviceDiscoveryResponse.set_can_play_native_media_during_vr(false);


### PR DESCRIPTION
Allows the OEMs to customize what they want to put as make,
model, manufacturer of the head unit to send to OpenAuto.
From https://github.com/f1xpl/openauto/pull/101